### PR TITLE
Fix linux path separator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# Kdevelop project files
+*.kdev4
+
 # =========================
 # Operating System Files
 # =========================

--- a/io_scene_mdl/mow/mdl.py
+++ b/io_scene_mdl/mow/mdl.py
@@ -31,7 +31,7 @@ class MDL:
 
 		# Create the root node with no parent
 		self.root_node = MDL_NODE.create_node_from_type('root', None)
-		self.root_node.path = os.path.dirname(filename) + '\\'
+		self.root_node.path = os.path.dirname(filename) + os.sep
 
 		# Open the file
 		self.open_file(filename)

--- a/io_scene_mdl/mow/mowdef.py
+++ b/io_scene_mdl/mow/mowdef.py
@@ -34,7 +34,7 @@ class MOWDEF:
 		self.root_node = MOWDEF_NODE.create_node_from_type('root', None)
 
 		# Add the path information to the root node
-		self.root_node.path = os.path.dirname(filename) + '\\'
+		self.root_node.path = os.path.dirname(filename) + os.sep
 
 		# Open the file and load its content into our self.data attribute
 		self.open_file(filename)

--- a/io_scene_mdl/mow/mowdef_node_place.py
+++ b/io_scene_mdl/mow/mowdef_node_place.py
@@ -21,6 +21,8 @@
 # Men of War MDL importer for Blender
 # Script Copyright (C) by Björn Martins Paz
 
+import os
+
 from mowdef import MOWDEF
 from mowdef_node import MOWDEF_NODE
 from mowdef_node_game_entity import MOWDEF_NODE_GAME_ENTITY
@@ -56,7 +58,7 @@ class MOWDEF_NODE_PLACE(MOWDEF_NODE):
 				# Check if we have a bone name and a game entity name
 				if self.bone_name and game_entity_name:
 					# Build a complete filepath to the .DEF file
-					filename = self.path + game_entity_name + '\\' + game_entity_name + '.def'
+					filename = self.path + game_entity_name + os.sep + game_entity_name + '.def'
 					print(filename)
 					# Load the .DEF file of the game entity
 					self.mowdefs.append(MOWDEF(filename))


### PR DESCRIPTION
Using os.sep instead of "\\" helps to support code on multiple OS.
In the same time *.kdevelop projects file are ignored from git, you could ask me to remove this if it is unwanted.